### PR TITLE
Fixed grammatical error in Line #267, addressing Issue #10.

### DIFF
--- a/lib/backend/data.dart
+++ b/lib/backend/data.dart
@@ -264,7 +264,7 @@ class Pages {
             setting: Settings.monet_engine_linear_lightness,
             title: "Use custom lightness scale",
             description:
-                "If enables it allows using the custom lightness scale",
+                "If enabled, it allows using the custom lightness scale",
           ),
           SliderSettingPreference<int>(
             setting: Settings.monet_engine_white_luminance_user,


### PR DESCRIPTION
"If ~enables~ enabled, it allows using the custom lightness scale."